### PR TITLE
Add DeepWiki component to MCP setup

### DIFF
--- a/setup/components/mcp.py
+++ b/setup/components/mcp.py
@@ -71,6 +71,12 @@ class MCPComponent(Component):
                 "config_file": "morphllm.json",
                 "requires_api_key": True,
                 "api_key_env": "MORPH_API_KEY"
+            },
+            "deepwiki": {
+                "name": "deepwiki",
+                "description": "Deep knowledge exploration and structured information retrieval",
+                "config_file": "deepwiki.json",
+                "requires_api_key": False
             }
         }
         


### PR DESCRIPTION
## Summary
- Introduces a new MCP component configuration for DeepWiki
- Enables deep knowledge exploration and structured information retrieval
- Does not require an API key for usage

## Changes

### MCP Component Setup
- Added `deepwiki` entry to MCP components in `setup/components/mcp.py`
  - Name: "deepwiki"
  - Description: "Deep knowledge exploration and structured information retrieval"
  - Config file: `deepwiki.json`
  - API key requirement: None

## Test plan
- Verify that the DeepWiki component is recognized and loaded correctly by the MCP setup
- Confirm no API key is required for DeepWiki component initialization
- Ensure no regressions in existing MCP components configuration

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f731affb-cd8e-46b8-8b3d-6e1fa020e87f